### PR TITLE
Strip {load position position} ed. and empty lines

### DIFF
--- a/packages/plg_system_socialmetatags/socialmetatags.php
+++ b/packages/plg_system_socialmetatags/socialmetatags.php
@@ -104,7 +104,8 @@ class PlgSystemSocialmetatags extends JPlugin
 			// If the article has a introtext, use it as description
             if(!empty($article->introtext))
             {
-                $description = trim(htmlspecialchars(strip_tags($article->introtext)));
+                $description = preg_replace('/{[\s\S]+?}/', '', trim(htmlspecialchars(strip_tags($article->introtext))));
+		$description = preg_replace('/\s\s+/', '', $description);
             }
 
 			// Set Twitter description


### PR DESCRIPTION
This change strips tags like `{loadpostion test}` or `{source code}` and empty lines in de generated description