### PR TITLE
Fix description and images

### DIFF
--- a/packages/plg_system_socialmetatags/socialmetatags.php
+++ b/packages/plg_system_socialmetatags/socialmetatags.php
@@ -104,7 +104,8 @@ class PlgSystemSocialmetatags extends JPlugin
 			// If the article has a introtext, use it as description
             if(!empty($article->introtext))
             {
-                $description = trim(htmlspecialchars(strip_tags($article->introtext)));
+				$description = preg_replace('/{[\s\S]+?}/', '', trim(htmlspecialchars(strip_tags($article->introtext))));
+				$description = preg_replace('/\s\s+/', ' ', $description);
             }
 
 			// Set Twitter description

--- a/packages/plg_system_socialmetatags/socialmetatags.php
+++ b/packages/plg_system_socialmetatags/socialmetatags.php
@@ -139,7 +139,13 @@ class PlgSystemSocialmetatags extends JPlugin
             {
 				// Get img tag from article
 				preg_match('/(?<!_)src=([\'"])?(.*?)\\1/', $article->fulltext, $articleimages);
-				$basicimage = JURI::current() . "/" . $articleimages[2];
+				$basicimage = JURI::base() . $articleimages[2];
+            }
+			elseif (strpos($article->introtext, '<img') !== false)
+            {
+				// Get img tag from article
+				preg_match('/(?<!_)src=([\'"])?(.*?)\\1/', $article->introtext, $articleimages);
+				$basicimage = JURI::base() . $articleimages[2];
             }
 
 			// Set publish and modifed time


### PR DESCRIPTION
This PR fix the following problems with the social image from an article:
- The wrong url was used
- We only check if there is an image in the introtext, but not if there is an image in the fulltext

And also make's sure that tags like `{loadposition ...}` `{source ...}` ed. and empty lines are striped from the description.