### PR TITLE
Correct update url

### DIFF
--- a/update/pkg_socialmetatags.xml
+++ b/update/pkg_socialmetatags.xml
@@ -14,7 +14,7 @@
     <infourl title="SocialMetaTags Package">https://github.com/hans2103/pkg_SocialMetaTags</infourl>
 
     <downloads>
-      <downloadurl type="full" format="zip">https://github.com/hans2103/pkg_SocialMetaTags/archive/v1.4.5.zip</downloadurl>
+      <downloadurl type="full" format="zip">https://github.com/hans2103/pkg_SocialMetaTags/archive/v.1.4.5.zip</downloadurl>
     </downloads>
 
     <tags>


### PR DESCRIPTION
The download url to the latest version was not correct. The url ended with `v1.4.5.zip`, but the latest version was called `v.1.4.5.zip`