### PR TITLE
Do not add the base url to external images

### DIFF
--- a/packages/plg_system_socialmetatags/socialmetatags.php
+++ b/packages/plg_system_socialmetatags/socialmetatags.php
@@ -305,13 +305,29 @@ class PlgSystemSocialmetatags extends JPlugin
 		{
 			// Get img tag from article
 			preg_match('/(?<!_)src=([\'"])?(.*?)\\1/', $article->fulltext, $articleimages);
-			$basicimage = JURI::base() . $articleimages[2];
+
+			if (preg_match('/^https?/', $articleimages[2]) === 1)
+			{
+				$basicimage = $articleimages[2];
+			}
+			else
+			{
+				$basicimage = JURI::base() . $articleimages[2];
+			}
 		}
 		elseif (strpos($article->introtext, '<img') !== false)
 		{
 			// Get img tag from article
 			preg_match('/(?<!_)src=([\'"])?(.*?)\\1/', $article->introtext, $articleimages);
-			$basicimage = JURI::base() . $articleimages[2];
+
+			if (preg_match('/^https?/', $articleimages[2]) === 1)
+			{
+				$basicimage = $articleimages[2];
+			}
+			else
+			{
+				$basicimage = JURI::base() . $articleimages[2];
+			}
 		}
 
 		return $basicimage;


### PR DESCRIPTION
## General
In a situation when no image is set, the plugin will search for images in the body of the article. In the current situation, the base url of the websites is always added to the found image url. If this found image is an external images the result will be invalid, something like: `https://site.nl/https://othersite.nl`.

## Test instruction
1. Create an article with a external images as body
2. Notice that in the meta header (for example `twitter:image:src`) is invalid
3. Apply this changes and verify the image url is now correct